### PR TITLE
Fix build error 16:13:58.532

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,4 @@
 {
   "buildCommand": "npm run build",
-  "outputDirectory": ".next",
-  "framework": "nextjs",
-  "functions": {
-    "src/app/**/*.{js,ts,jsx,tsx}": {
-      "runtime": "nodejs18.x"
-    }
-  },
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "/"
-    }
-  ]
+  "framework": "nextjs"
 }


### PR DESCRIPTION
Remove unnecessary Vercel configuration from `vercel.json` to fix "Function Runtimes must have a valid version" error.

The previous `vercel.json` included explicit function runtime configurations, output directory specifications, and custom routing rules. For Next.js applications, Vercel automatically handles these aspects, and the manual configuration was causing a deployment error. Simplifying the `vercel.json` to only include `buildCommand` and `framework` allows Vercel to correctly detect and deploy the Next.js application.

---
<a href="https://cursor.com/background-agent?bcId=bc-562a5986-4ed0-43a1-af79-bdddd56c317c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-562a5986-4ed0-43a1-af79-bdddd56c317c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

